### PR TITLE
Add LIFOCostBasisCalculator and tests

### DIFF
--- a/src/tax/basis.js
+++ b/src/tax/basis.js
@@ -1,0 +1,79 @@
+// @flow
+
+import moment from "moment";
+import Big from "big.js";
+import type {Transaction} from "../core/transaction";
+
+export type BasisFrame = {
+  date: moment,
+  amount: Big,
+  unitCost: Big,
+};
+
+/** A cost basis calculator with LIFO (Last In, First Out) semantics.
+ * Any time that a currency is being disposed of (e.g. sold or gifted),
+ * it reports the effective cost basis for that amount of currency, by
+ * returning the appropriate BasisFrames. Note that it may return several
+ * BasisFrames, e.g. if you acquired 50 at one cost, 50 at another cost, and then
+ * dispose of 75, you will get 2 frames (50 from the last frame, 25 from the first one).
+ */
+export class LIFOCostBasisCalculator {
+  frames: BasisFrame[];
+  ticker: string;
+
+  constructor(ticker: string) {
+    this.frames = [];
+    this.ticker = ticker;
+  }
+
+  /** Record that a cryptocurrency was acquired at a certain cost */
+  acquire(tx: Transaction) {
+    if (tx.ticker !== this.ticker) {
+      throw new Error(`LIFOCostBasisCalculator with ticker
+        ${this.ticker} tried to process transaction with ticker ${tx.ticker}`);
+    }
+    const frame = {amount: tx.amount, unitCost: tx.price, date: tx.date};
+    this.frames.push(frame);
+  }
+
+  /** Record that a cryptocurrency was disposed of, and retrieve the associated
+   * basis frames */
+  dispose(tx: Transaction): BasisFrame[] {
+    if (tx.ticker !== this.ticker) {
+      throw new Error(
+        `LIFOCostBasisCalculator with ticker` +
+          `${this.ticker} tried to process transaction with ticker ${tx.ticker}`
+      );
+    }
+    let remainToBeSold = tx.amount;
+    let basisFrames = [];
+    while (remainToBeSold.gt(0)) {
+      if (this.frames.length === 0) {
+        throw new Error(
+          `Attempted to dispose ${remainToBeSold.toString()} ` +
+            `${this.ticker}, but none remained`
+        );
+      }
+      let nextFrame = this.frames[this.frames.length - 1];
+
+      let amountSold;
+      if (nextFrame.amount.gt(remainToBeSold)) {
+        amountSold = remainToBeSold;
+        remainToBeSold = Big(0);
+        nextFrame.amount = nextFrame.amount.minus(amountSold);
+      } else {
+        amountSold = nextFrame.amount;
+        this.frames.pop();
+        remainToBeSold = remainToBeSold.minus(amountSold);
+      }
+      const basisFrame = {
+        date: nextFrame.date,
+        unitCost: nextFrame.unitCost,
+        amount: amountSold,
+      };
+      basisFrames.push(basisFrame);
+    }
+
+    return basisFrames;
+  }
+}

--- a/src/tax/basis.test.js
+++ b/src/tax/basis.test.js
@@ -1,0 +1,88 @@
+// @flow
+
+import moment from "moment";
+import Big from "big.js";
+import type {BasisFrame} from "./basis";
+import type {Transaction} from "../core/transaction";
+import {LIFOCostBasisCalculator} from "./basis";
+
+describe("cost basis calculation", () => {
+  const dateFromYear = (x) =>
+    moment().set({
+      year: x,
+      month: 0,
+      day: 0,
+      hour: 0,
+      minute: 0,
+      second: 0,
+      millisecond: 0,
+    });
+  function acquireTx(year, amount, price): Transaction {
+    return {
+      ticker: "FOO",
+      amount: Big(amount),
+      date: dateFromYear(year),
+      price: Big(price),
+      type: "TRADE",
+    };
+  }
+
+  function disposeTx(amount) {
+    return {
+      ticker: "FOO",
+      amount: Big(amount),
+      date: moment(),
+      price: Big(100),
+      type: "TRADE",
+    };
+  }
+  it("works in a trivial case", () => {
+    const calc = new LIFOCostBasisCalculator("FOO");
+    calc.acquire(acquireTx(1990, 1, 100));
+    const results = calc.dispose(disposeTx(1));
+    expect(results).toEqual([
+      {amount: Big(1), unitCost: Big(100), date: dateFromYear(1990)},
+    ]);
+  });
+
+  it("uses LIFO semantics", () => {
+    const calc = new LIFOCostBasisCalculator("FOO");
+    calc.acquire(acquireTx(1990, 1, 100));
+    calc.acquire(acquireTx(1991, 1, 200));
+    const results = calc.dispose(disposeTx(1.5));
+    expect(results).toEqual([
+      {amount: Big(1), unitCost: Big(200), date: dateFromYear(1991)},
+      {amount: Big(0.5), unitCost: Big(100), date: dateFromYear(1990)},
+    ]);
+  });
+
+  it("throws error when disposing without acquiring", () => {
+    const calc = new LIFOCostBasisCalculator("FOO");
+    expect(() => calc.dispose(disposeTx(3))).toThrow("none remained");
+  });
+
+  it("works with longer sequences of dispose and acquire", () => {
+    // note it tests LIFO semantics here
+    const calc = new LIFOCostBasisCalculator("FOO");
+    calc.acquire(acquireTx(1990, 5, 100));
+    calc.acquire(acquireTx(1991, 5, 200));
+    const dispose0 = calc.dispose(disposeTx(3));
+    expect(dispose0).toEqual([
+      {unitCost: Big(200), amount: Big(3), date: dateFromYear(1991)},
+    ]);
+    const dispose1 = calc.dispose(disposeTx(6));
+    expect(dispose1).toEqual([
+      {unitCost: Big(200), amount: Big(2), date: dateFromYear(1991)},
+      {unitCost: Big(100), amount: Big(4), date: dateFromYear(1990)},
+    ]);
+
+    calc.acquire(acquireTx(1992, 2, 500));
+    const dispose2 = calc.dispose(disposeTx(3));
+    expect(dispose2).toEqual([
+      {unitCost: Big(500), amount: Big(2), date: dateFromYear(1992)},
+      {unitCost: Big(100), amount: Big(1), date: dateFromYear(1990)},
+    ]);
+
+    expect(() => calc.dispose(disposeTx(1))).toThrow("none remained");
+  });
+});


### PR DESCRIPTION
The LIFOCostBasisCalculator keeps track of a sequence of acquisitions
and disposals for a given cryptocurrency. For each disposal, it reports
a sequence of `BasisFrames`; these BasisFrames have the cost basis
information for that disposal (when the corresponding crypto was
acquired, and at what cost).

Test plan: Check out the new tests that have been added. They pass, as
does `yarn flow`.