### PR TITLE
Add logic for computing capital gains

### DIFF
--- a/src/tax/capitalGains.js
+++ b/src/tax/capitalGains.js
@@ -1,0 +1,66 @@
+// @flow
+
+import moment from "moment";
+import Big from "big.js";
+
+import type {BasisFrame} from "./basis";
+import {LIFOCostBasisCalculator} from "./basis";
+import type {Transaction} from "../core/transaction";
+import {transactionTypes} from "../core/transaction";
+
+export type CapitalGainsRecord = {
+  amount: Big,
+  ticker: string,
+  acquiredDate: moment,
+  disposedDate: moment,
+  unitCost: Big, // cost from buying the position
+  unitProceeds: Big, // proceeds from selling the position
+  // ergo gains_in_dollars = (unitProceeds - unitCost) * amount;
+  gainsType: "SHORT_TERM" | "LONG_TERM",
+};
+
+/** For a given ticker, keep track of all of the capital gains that result from
+ * buying and selling it. Currently it always uses LIFO basis calculation, but
+ * it's straightforward to swap implementations. */
+export class CapitalGainsCalculator {
+  basisCalc: LIFOCostBasisCalculator;
+  ticker: string;
+
+  constructor(ticker: string) {
+    this.basisCalc = new LIFOCostBasisCalculator(ticker);
+    this.ticker = ticker;
+  }
+
+  acquire(tx: Transaction) {
+    this.basisCalc.acquire(tx);
+  }
+
+  /** Dispose of some amount of crypto at a given price. If disposing in a
+   * tax-exempt manner (e.g. giving a gift), then the price is irrelevant as no
+   * gains will be produced, but it is still essential to call dispose so that
+   * future cost basis calculations will be accurate.
+   */
+  dispose(tx: Transaction): CapitalGainsRecord[] {
+    const frames = this.basisCalc.dispose(tx);
+    if (!transactionTypes[tx.type].isCapitalGains) {
+      return [];
+    }
+    return frames.map((f) => {
+      // See test cases to verify that this logic is correct
+      const isLongTerm = f.date
+        .clone()
+        .add(1, "years")
+        .isBefore(tx.date, "day");
+      const gains = {
+        amount: f.amount,
+        ticker: this.ticker,
+        acquiredDate: f.date,
+        disposedDate: tx.date,
+        price: tx.price,
+        unitCost: f.unitCost,
+        gainsType: isLongTerm ? "LONG_TERM" : "SHORT_TERM",
+      };
+      return gains;
+    });
+  }
+}

--- a/src/tax/capitalGains.test.js
+++ b/src/tax/capitalGains.test.js
@@ -1,0 +1,122 @@
+// @flow
+
+import moment from "moment";
+import Big from "big.js";
+
+import type {Transaction} from "../core/transaction";
+import {CapitalGainsCalculator} from "./capitalGains";
+
+describe("capital gains calculation", () => {
+  const date = (y, m, d) =>
+    moment().set({
+      year: y,
+      month: m,
+      date: d,
+      hours: 0,
+      minutes: 0,
+      seconds: 0,
+      milliseconds: 0,
+    });
+
+  function acquireTx(date, amount, price) {
+    return {
+      ticker: "FOO",
+      amount: Big(amount),
+      date,
+      price: Big(price),
+      type: "TRADE",
+    };
+  }
+
+  function disposeTx(date, amount, price) {
+    return {
+      ticker: "FOO",
+      amount: Big(amount),
+      date,
+      price: Big(price),
+      type: "TRADE",
+    };
+  }
+
+  describe("short-term vs long-term: precise time boundaries", () => {
+    function expectTerm(acquireDate, disposeDate, gainsType) {
+      const calc = new CapitalGainsCalculator("FOO");
+      calc.acquire(acquireTx(acquireDate, 1, 1));
+      const gains = calc.dispose(disposeTx(disposeDate, 1, 1));
+      expect(gains).toHaveLength(1);
+      expect(gains[0].gainsType).toEqual(gainsType);
+    }
+    const acquireDate = () => date(2015, 0, 0);
+    const stDate = () => date(2016, 0, 0);
+    const ltDate = () => date(2016, 0, 1);
+    // The time of day doesn't matter, so let's try a few permutations
+    function makeLate(m) {
+      return m.clone().set({hour: 22, minute: 58});
+    }
+
+    it("short-term gains from a one-year hold", () => {
+      expectTerm(acquireDate(), stDate(), "SHORT_TERM");
+    });
+    it("short-term gains from a one-year hold (late acquire)", () => {
+      expectTerm(makeLate(acquireDate()), stDate(), "SHORT_TERM");
+    });
+    it("short-term gains from a one-year hold (late sell)", () => {
+      expectTerm(acquireDate(), makeLate(stDate()), "SHORT_TERM");
+    });
+
+    it("long-term gains from a one-year and one day hold", () => {
+      expectTerm(acquireDate(), ltDate(), "LONG_TERM");
+    });
+    it("long-term gains from a one-year and one day hold (late acquire)", () => {
+      expectTerm(makeLate(acquireDate()), ltDate(), "LONG_TERM");
+    });
+    it("long-term gains from a one-year and one day hold (late sell)", () => {
+      expectTerm(acquireDate(), makeLate(ltDate()), "LONG_TERM");
+    });
+  });
+
+  it("one sale can generate a mix of short- and long- term gains", () => {
+    const calc = new CapitalGainsCalculator("FOO");
+    calc.acquire(acquireTx(date(2015, 1, 1), 100, 1.0));
+    calc.acquire(acquireTx(date(2015, 6, 6), 50, 2.0));
+    const gains = calc.dispose(disposeTx(date(2016, 2, 1), 120, 1.5));
+
+    expect(gains).toEqual([
+      {
+        amount: Big(50),
+        ticker: "FOO",
+        acquiredDate: date(2015, 6, 6),
+        disposedDate: date(2016, 2, 1),
+        price: Big(1.5),
+        unitCost: Big(2.0),
+        gainsType: "SHORT_TERM",
+      },
+      {
+        amount: Big(70),
+        ticker: "FOO",
+        acquiredDate: date(2015, 1, 1),
+        disposedDate: date(2016, 2, 1),
+        price: Big(1.5),
+        unitCost: Big(1.0),
+        gainsType: "LONG_TERM",
+      },
+    ]);
+  });
+
+  it("processes tax exempt transactions for basis calc (but not gains)", () => {
+    const calc = new CapitalGainsCalculator("FOO");
+    calc.acquire(acquireTx(date(2015, 1, 1), 100, 1.0));
+    const gainsExemptDisposeTx: Transaction = {
+      date: date(2015, 1, 2),
+      price: Big(10),
+      amount: Big(100),
+      type: "GIFT",
+      ticker: "FOO",
+    };
+    const gains = calc.dispose(gainsExemptDisposeTx);
+    expect(gains).toHaveLength(0);
+    expect(() => calc.dispose(disposeTx(date(2015, 1, 2), 100, 1.0))).toThrow(
+      "none remained"
+    );
+  });
+});


### PR DESCRIPTION
The CapitalGainsCalculator contains a CostBasisCalculator, and uses it
to generate CapitalGainsRecords from a sequence of buys and sells.
It supports marking certain sells as tax exempt (e.g. gifts).

Test plan:
New tests for the behavior, especially the precise time boundary around
long-term/short-term gains. Observe that they pass, and that `yarn flow`
works.