### PR TITLE
Add a transaction datatype

### DIFF
--- a/src/core/transaction.js
+++ b/src/core/transaction.js
@@ -1,0 +1,52 @@
+// @flow
+
+import moment from "moment";
+
+export const transactionTypes = [
+  "FUNDING", // as when I transfer $10k into Coinbase
+  "FORK", // as with Bitcoin Cash
+  "FEE", // eg exchange fee
+  "SPEND", // buy real world thing w/ crypto
+  "DIV", // dividends from proof-of-stake
+  "GIFT", // giving away cryptos (tax exempt)
+  "TRADE", // acquired/disposed via a trade
+];
+
+export type Transaction = {
+  ticker: string,
+  price: number,
+  amount: number,
+  date: moment,
+  type: typeof transactionTypes,
+};
+
+export function isCapitalGains(tx: Transaction) {
+  switch (tx.type) {
+    case "TRADE":
+    case "SPEND":
+      return true;
+    case "GIFT":
+    case "DIV":
+    case "FEE":
+    case "FORK":
+    case "FUNDING":
+      return false;
+    default:
+      throw new Error(`Unexpected transaction type ${tx.type}`);
+  }
+}
+export function isIncomeOrLoss(tx: Transaction) {
+  switch (tx.type) {
+    case "DIV":
+    case "FEE":
+    case "FORK":
+      return true;
+    case "TRADE":
+    case "SPEND":
+    case "GIFT":
+    case "FUNDING":
+      return false;
+    default:
+      throw new Error(`Unexpected transaction type ${tx.type}`);
+  }
+}

--- a/src/core/transaction.test.js
+++ b/src/core/transaction.test.js
@@ -1,0 +1,44 @@
+// @flow
+
+import moment from "moment";
+import type {Transaction} from "./transaction";
+import {transactionTypes, isCapitalGains, isIncomeOrLoss} from "./transaction";
+
+describe("transaction type classification", () => {
+  // I don't test the outputs of isCapitalGains or isIncomeOrLoss because the
+  // implementations are trivial. Instead, I just verify that they cover every
+  // defined transaction type, and error on unknown tx types.
+  const transactionForEachType = transactionTypes.map((t) => {
+    const transaction = {
+      ticker: "foo",
+      price: 1,
+      amount: 1,
+      date: moment(),
+      type: t,
+    };
+    return transaction;
+  });
+  it("isIncomeOrLoss does not error on any exported transaction type", () => {
+    transactionForEachType.forEach((t) => isIncomeOrLoss(t));
+  });
+  it("isCapitalGains does not error on any exported transaction type", () => {
+    transactionForEachType.forEach((t) => isCapitalGains(t));
+  });
+  const badTransaction = {
+    ticker: "foo",
+    price: 1,
+    amount: 1,
+    date: moment(),
+    type: "BAD_UNRECOGNIZED",
+  };
+  it("isIncomeOrLoss errors on bad tx type", () => {
+    expect(() => isIncomeOrLoss(badTransaction)).toThrow(
+      "Unexpected transaction type"
+    );
+  });
+  it("isCapitalGains errors on bad tx type", () => {
+    expect(() => isCapitalGains(badTransaction)).toThrow(
+      "Unexpected transaction type"
+    );
+  });
+});


### PR DESCRIPTION
The `Transaction` will be the core atomic data type for representing
acquiring or disposing of a particular crypto. It has ticker, price (in
USD), date, amount, and info on what type of transaction it is. There
are helper functions with tax relevant info based on the type (is it
generating capital gains, is it income or loss).

Note that crypto-to-crypto trades are very common, and those are
represented by two transactions: one transaction that sells the source
crypto for USD, and one transaction that buys the destination crypto for
USD. From a tax compliance standpoint, this is the right way to do it,
and it has the addon benefits of allowing all the core tx processing
code to just handle a single datatype. There is no need for an explicit
enum distinguishing buys from sells, because it is obvious from looking
at the amount (negative amount implies sell, positive amount implies
buy).

In a followon PR, I intend to make the CostBasisCalculator and
CapitalGainsCalculator use transactions rather than taking a subset of
the transaction fields as function arguments. I expect this to be more
readable (don't need to remember which is price and which is amount),
and make the codebase more consistent.

Test plan:
The implementation of this PR is quite trivial. I added tests that
verify that every transaction type is handled by the transaction
categorizers, and that the categorizers would error if provided an
unexpected tx type. I didn't bother testing the outputs of those
functions due to their trivial implementations.