### PR TITLE
Add a Transaction datatype

### DIFF
--- a/flow-typed/npm/big.js_v3.x.x.js
+++ b/flow-typed/npm/big.js_v3.x.x.js
@@ -1,0 +1,54 @@
+// flow-typed signature: 79b221104fdff0ceeae3353a5b8437b2
+// flow-typed version: da30fe6876/big.js_v3.x.x/flow_>=v0.25.x
+
+declare module "big.js" {
+  declare type $npm$big$number$object = number | string | Big;
+  declare type $npm$cmp$result = -1 | 0 | 1;
+  declare type DIGIT = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+  declare type ROUND_DOWN = 0;
+  declare type ROUND_HALF_UP = 1;
+  declare type ROUND_HALF_EVEN = 2;
+  declare type ROUND_UP = 3;
+  declare type RM = ROUND_DOWN | ROUND_HALF_UP | ROUND_HALF_EVEN | ROUND_UP;
+
+  declare class Big {
+    // Properties
+    static DP: number;
+    static RM: RM;
+    static E_NEG: number;
+    static E_POS: number;
+
+    c: Array<DIGIT>;
+    e: number;
+    s: -1 | 1;
+
+    // Constructors
+    static (value: $npm$big$number$object): Big;
+    constructor(value: $npm$big$number$object): Big;
+
+    // Methods
+    abs(): Big;
+    cmp(n: $npm$big$number$object): $npm$cmp$result;
+    div(n: $npm$big$number$object): Big;
+    eq(n: $npm$big$number$object): boolean;
+    gt(n: $npm$big$number$object): boolean;
+    gte(n: $npm$big$number$object): boolean;
+    lt(n: $npm$big$number$object): boolean;
+    lte(n: $npm$big$number$object): boolean;
+    minus(n: $npm$big$number$object): Big;
+    mod(n: $npm$big$number$object): Big;
+    plus(n: $npm$big$number$object): Big;
+    pow(exp: number): Big;
+    round(dp: ?number, rm: ?RM): Big;
+    sqrt(): Big;
+    times(n: $npm$big$number$object): Big;
+    toExponential(dp: ?number): string;
+    toFixed(dp: ?number): string;
+    toPrecision(sd: ?number): string;
+    toString(): string;
+    valueOf(): string;
+    toJSON(): string;
+  }
+
+  declare module.exports: typeof Big;
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "babel-loader": "7.1.2",
     "babel-preset-react-app": "^3.1.1",
     "babel-runtime": "6.26.0",
+    "big.js": "^3.0.3",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
     "css-loader": "0.28.7",

--- a/src/core/transaction.js
+++ b/src/core/transaction.js
@@ -1,0 +1,36 @@
+// @flow
+
+import moment from "moment";
+import Big from "big.js";
+
+export type TransactionTypeInfo = {
+  // Whether transactions of this type generate capital gains (when they are a disposal,
+  // e.g. the sell end of a trade)
+  isCapitalGains: boolean,
+  // Whether transactions of this type are raw income (or loss),
+  // e.g. a dividend or a fork
+  isIncome: boolean,
+};
+
+export const transactionTypes = {
+  FUNDING: {isCapitalGains: false, isIncome: false}, // as when I transfer $10k into Coinbase
+  FORK: {isCapitalGains: false, isIncome: true}, // as with Bitcoin Cash
+  FEE: {isCapitalGains: false, isIncome: true}, // eg exchange fee
+  SPEND: {isCapitalGains: true, isIncome: false}, // buy real world thing w/ crypto
+  DIV: {isCapitalGains: false, isIncome: true}, // dividends from proof-of-stake
+  GIFT: {isCapitalGains: false, isIncome: false}, // giving away cryptos (tax exempt)
+  TRADE: {isCapitalGains: true, isIncome: false}, // acquired/disposed via a trade
+};
+
+// eslint-disable-next-line no-unused-expressions
+(function staticTypeCheck() {
+  return (x: $Values<typeof transactionTypes>): TransactionTypeInfo => x;
+});
+
+export type Transaction = {
+  ticker: string,
+  price: Big,
+  amount: Big,
+  date: moment,
+  type: $Keys<typeof transactionTypes>,
+};

--- a/src/core/transaction.test.js
+++ b/src/core/transaction.test.js
@@ -1,0 +1,43 @@
+// @flow
+
+import moment from "moment";
+import Big from "big.js";
+
+import type {Transaction} from "./transaction";
+
+describe("transaction typechecking", () => {
+  it("can construct transaction for various transaction types", () => {
+    // Not intended to be exhaustive, just verifying that the element types work
+    const trade: Transaction = {
+      price: Big(1),
+      amount: Big(2),
+      ticker: "FOO",
+      date: moment(),
+      type: "TRADE",
+    };
+    const gift: Transaction = {
+      price: Big(1),
+      amount: Big(2),
+      ticker: "FOO",
+      date: moment(),
+      type: "GIFT",
+    };
+    const fork: Transaction = {
+      price: Big(1),
+      amount: Big(2),
+      ticker: "FOO",
+      date: moment(),
+      type: "FORK",
+    };
+  });
+  //  it("invalid transaction types produce flow errors", () => {
+  //    // if uncommented, this test produces a flow error
+  //    const bad: Transaction = {
+  //      price: Big(1),
+  //      amount: Big(2),
+  //      ticker: "FOO",
+  //      date: moment(),
+  //      type: "BAD",
+  //    };
+  //  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,7 +1054,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-big.js@^3.1.3:
+big.js@^3.0.3, big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 


### PR DESCRIPTION
It is a standard way of representing acquiring or disposing of some
cryptoasset. It uses bigjs arbitrary-precision numeric representations
for the cryptocurrency amount and price.

There are a number of transaction types, such as "TRADE", "FEE", and
"DIV". Each transaction type is associated with a TransactionTypeInfo,
with information on the tax implications of that kind of transaction.

Test plan:
The tests thus far all focus on typechecking. Observe that `yarn flow`
and `yarn test` both pass at present.

If you uncomment the invalid transaction in transaction.test.js, then
`yarn flow` produces errors. Also, if you make the transactionTypes not
all map to a TransactionTypeInfo (e.g. change isCapitalGains to "foo"
for some tx type), then `yarn flow` fails in the static assertion.