### PR TITLE
Add txSource to transactions, and field descriptions

### DIFF
--- a/src/core/transaction.js
+++ b/src/core/transaction.js
@@ -3,6 +3,30 @@
 import moment from "moment";
 import Big from "big.js";
 
+// Any time the portfolio gains or loses any asset, we record a transaction for
+// that asset.
+// Some events may trigger multiple transactions: for example, trading A for B
+// and then paying a fee in B would generate three transactions: losing A,
+// gaining B, and paying the fee
+export type Transaction = {
+  // The (traditionally 3-letter) ticker of the asset being traded
+  ticker: string,
+  // The per-unit price in USD of the asset, at the time of the transaction.
+  // Having a price does not imply that any dollars actually changed hands (if
+  // they did, that will be recorded in an additional transaction). For tax
+  // purposes, we track the price on every occasion that we acquire or dispose
+  // of property.
+  price: Big,
+  // The amount of this asset that the portfolio acquired or disposed
+  amount: Big,
+  // The date of the transaction
+  date: moment,
+  // The type (from transactionTypes) of the transaction
+  type: $Keys<typeof transactionTypes>,
+  // A string describing the data source we imported the transaction from
+  txSource: string,
+};
+
 export type TransactionTypeInfo = {
   // Whether transactions of this type generate capital gains (when they are a disposal,
   // e.g. the sell end of a trade)
@@ -26,11 +50,3 @@ export const transactionTypes = {
 (function staticTypeCheck() {
   return (x: $Values<typeof transactionTypes>): TransactionTypeInfo => x;
 });
-
-export type Transaction = {
-  ticker: string,
-  price: Big,
-  amount: Big,
-  date: moment,
-  type: $Keys<typeof transactionTypes>,
-};

--- a/src/core/transaction.test.js
+++ b/src/core/transaction.test.js
@@ -14,6 +14,7 @@ describe("transaction typechecking", () => {
       ticker: "FOO",
       date: moment(),
       type: "TRADE",
+      txSource: "test",
     };
     const gift: Transaction = {
       price: Big(1),
@@ -21,6 +22,7 @@ describe("transaction typechecking", () => {
       ticker: "FOO",
       date: moment(),
       type: "GIFT",
+      txSource: "test",
     };
     const fork: Transaction = {
       price: Big(1),
@@ -28,6 +30,7 @@ describe("transaction typechecking", () => {
       ticker: "FOO",
       date: moment(),
       type: "FORK",
+      txSource: "test",
     };
   });
   //  it("invalid transaction types produce flow errors", () => {
@@ -38,6 +41,7 @@ describe("transaction typechecking", () => {
   //      ticker: "FOO",
   //      date: moment(),
   //      type: "BAD",
+  //      txSource: "test",
   //    };
   //  });
 });

--- a/src/tax/basis.test.js
+++ b/src/tax/basis.test.js
@@ -24,6 +24,7 @@ describe("cost basis calculation", () => {
       date: dateFromYear(year),
       price: Big(price),
       type: "TRADE",
+      txSource: "test",
     };
   }
 
@@ -34,6 +35,7 @@ describe("cost basis calculation", () => {
       date: moment(),
       price: Big(100),
       type: "TRADE",
+      txSource: "test",
     };
   }
   it("works in a trivial case", () => {

--- a/src/tax/capitalGains.js
+++ b/src/tax/capitalGains.js
@@ -56,7 +56,7 @@ export class CapitalGainsCalculator {
         ticker: this.ticker,
         acquiredDate: f.date,
         disposedDate: tx.date,
-        price: tx.price,
+        unitProceeds: tx.price,
         unitCost: f.unitCost,
         gainsType: isLongTerm ? "LONG_TERM" : "SHORT_TERM",
       };

--- a/src/tax/capitalGains.test.js
+++ b/src/tax/capitalGains.test.js
@@ -18,23 +18,25 @@ describe("capital gains calculation", () => {
       milliseconds: 0,
     });
 
-  function acquireTx(date, amount, price) {
+  function acquireTx(date, amount, price): Transaction {
     return {
       ticker: "FOO",
       amount: Big(amount),
       date,
       price: Big(price),
       type: "TRADE",
+      txSource: "test",
     };
   }
 
-  function disposeTx(date, amount, price) {
+  function disposeTx(date, amount, price): Transaction {
     return {
       ticker: "FOO",
       amount: Big(amount),
       date,
       price: Big(price),
       type: "TRADE",
+      txSource: "test",
     };
   }
 
@@ -87,7 +89,7 @@ describe("capital gains calculation", () => {
         ticker: "FOO",
         acquiredDate: date(2015, 6, 6),
         disposedDate: date(2016, 2, 1),
-        price: Big(1.5),
+        unitProceeds: Big(1.5),
         unitCost: Big(2.0),
         gainsType: "SHORT_TERM",
       },
@@ -96,7 +98,7 @@ describe("capital gains calculation", () => {
         ticker: "FOO",
         acquiredDate: date(2015, 1, 1),
         disposedDate: date(2016, 2, 1),
-        price: Big(1.5),
+        unitProceeds: Big(1.5),
         unitCost: Big(1.0),
         gainsType: "LONG_TERM",
       },
@@ -112,6 +114,7 @@ describe("capital gains calculation", () => {
       amount: Big(100),
       type: "GIFT",
       ticker: "FOO",
+      txSource: "test",
     };
     const gains = calc.dispose(gainsExemptDisposeTx);
     expect(gains).toHaveLength(0);


### PR DESCRIPTION
It will be helpful to be able to trace a transaction back to whichever
data importer was responsible for finding it.

Also, add comment descriptors to the transaction fields.